### PR TITLE
scaling down with suspend while restart

### DIFF
--- a/babe
+++ b/babe
@@ -392,10 +392,10 @@ def restartCommand(restartOptionsParser):
         return
     parallelism = restartOptionsParser.parallelism
     targetScale=len(instances)
-    if parallelism >= targetScale/2 :
-        print("parallelism can not be more than or equal to "+ str(int(targetScale/2)))
-        return
     if parallelism > 1:
+        if parallelism >= targetScale / 2:
+            print("parallelism can not be more than or equal to " + str(int(targetScale / 2)))
+            return
         if restartOptionsParser.noScaling == False:
             targetScale=len(instances) + parallelism
             scale(appName, targetScale)

--- a/babe
+++ b/babe
@@ -393,7 +393,7 @@ def restartCommand(restartOptionsParser):
     parallelism = restartOptionsParser.parallelism
     targetScale=len(instances)
     if parallelism >= targetScale/2 :
-        print("parallelism can not be more than "+ str(int(targetScale/2)))
+        print("parallelism can not be more than or equal to "+ str(int(targetScale/2)))
         return
     if parallelism > 1:
         if restartOptionsParser.noScaling == False:
@@ -402,15 +402,16 @@ def restartCommand(restartOptionsParser):
             waitForTargetScale(appName, targetScale)
         for i in tqdm.tqdm(range(0, len(instances), parallelism)):
             instances_batch = instances[i:i+parallelism]
-            suspendParallel(appName, instances_batch, grace, rangerOOR, lbOOR, parallelism, False)
-            if(i+parallelism >= len(instances)-parallelism) :
-                scale(appName, targetScale - parallelism)
-                waitForTargetScale(appName, targetScale - parallelism)
+            if(i+parallelism > len(instances)-parallelism and len(instances_batch) == parallelism) :
+                print("suspending with scale down")
+                suspendParallel(appName, instances_batch, grace, rangerOOR, lbOOR, parallelism, True)
+                targetScale = targetScale - parallelism
             else :
+                suspendParallel(appName, instances_batch, grace, rangerOOR, lbOOR, parallelism, False)
                 waitForTargetScale(appName, targetScale)
         if restartOptionsParser.noScaling == False:
-            scale(appName, targetScale - parallelism)
-            waitForTargetScale(appName, targetScale - parallelism)
+            scale(appName, targetScale)
+            waitForTargetScale(appName, targetScale)
         print("App Restarted")
     else :
         if restartOptionsParser.noScaling == False:

--- a/babe
+++ b/babe
@@ -393,8 +393,11 @@ def restartCommand(restartOptionsParser):
     parallelism = restartOptionsParser.parallelism
     targetScale=len(instances)
     if parallelism > 1:
-        if parallelism >= targetScale / 2:
-            print("parallelism can not be more than or equal to " + str(int(targetScale / 2)))
+        maxAllowedParallelism = int(targetScale/2)
+        if(maxAllowedParallelism<1) :
+            maxAllowedParallelism = 1
+        if parallelism >= maxAllowedParallelism:
+            print("parallelism can not be more than " + str(maxAllowedParallelism))
             return
         if restartOptionsParser.noScaling == False:
             targetScale=len(instances) + parallelism


### PR DESCRIPTION
There was still a possibility of instances getting killed without OOR.
Fixed in this version, as scaling down at the time of suspending the last batch. 